### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,4 @@
 # Travis info
 .travis.yml
 
-Gruntfile.yml
+Gruntfile.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+.gitignore
+
+# Linter setups
+.jscsrc
+.jsfmtrc
+.jshintrc
+
+# Travis info
+.travis.yml
+
+Gruntfile.yml

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,5 @@
 .travis.yml
 
 Gruntfile.js
+
+test


### PR DESCRIPTION
This will reduce the number of files distributed with the npm package, making the package smaller and more attractive to potential users.
